### PR TITLE
updating iam access key with depend on feature

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -12,6 +12,10 @@ resource "aws_iam_access_key" "newhirekeys" {
   count = length(var.iam_names)
   user  = element(var.iam_names, count.index)
 
+  depends_on = [
+    #aws_iam_user_policy.newhire_policy
+    aws_iam_user.newemployees
+  ]
 }
 
 resource "aws_iam_account_password_policy" "strict" {


### PR DESCRIPTION
hi, when I run the apply option via TF cloud I got into an error. It seems like it wanted to create the keys before it can create the user.

I added a depends on the function and this prevented the error, take a look and maybe we can test again.
---------------------------------------------------------------------------------------------------------


Error: Error creating access key for user kjohnson: NoSuchEntity: The user with name kjohnson cannot be found. status code: 404, request id: fdc4be34-899f-4302-8d4c-713c9498453d
with aws_iam_access_key.newhirekeys[3]
on iam.tf line 11, in resource "aws_iam_access_key" "newhirekeys":
resource "aws_iam_access_key" "newhirekeys" {




![image](https://user-images.githubusercontent.com/66052039/122571433-a33d7700-d044-11eb-8608-0658e2cf19e0.png)
